### PR TITLE
feat(canvas): 캔버스 펜/하이라이터/지우개 도구 시스템 완성

### DIFF
--- a/lib/models/canvas_color.dart
+++ b/lib/models/canvas_color.dart
@@ -15,6 +15,12 @@ enum CanvasColor {
   /// 실제 Color 값
   final Color color;
 
+  /// 하이라이터용 반투명 색상 (50% 투명도)
+  Color get highlighterColor => color.withAlpha(50);
+
+  /// 지정된 투명도로 색상 생성
+  Color withOpacity(double opacity) => color.withValues(alpha: opacity);
+
   /// 모든 색상 리스트 (UI 구성용)
   static List<CanvasColor> get all => CanvasColor.values;
 

--- a/lib/models/custom_scribble_notifier.dart
+++ b/lib/models/custom_scribble_notifier.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:scribble/scribble.dart';
 
 import '../data/sketches.dart';
+import 'canvas_color.dart';
+import 'tool_mode.dart';
 
 class CustomScribbleNotifier extends ScribbleNotifier {
   CustomScribbleNotifier({
@@ -15,10 +17,13 @@ class CustomScribbleNotifier extends ScribbleNotifier {
     super.simplifier,
     super.simplificationTolerance,
     required this.canvasIndex,
+    required this.toolMode,
   });
 
   final int canvasIndex;
+  ToolMode toolMode;
 
+  /// 자동저장 구현
   @override
   void onPointerUp(PointerUpEvent event) {
     super.onPointerUp(event);
@@ -28,5 +33,77 @@ class CustomScribbleNotifier extends ScribbleNotifier {
   void _saveSketch() {
     final json = currentSketch.toJson();
     sketches[canvasIndex].jsonData = jsonEncode(json);
+  }
+
+  void setPen() {
+    toolMode = ToolMode.pen;
+    temporaryValue = value.map(
+      // 현재 상태가 drawing 일 때
+      drawing: (s) => ScribbleState.drawing(
+        sketch: s.sketch,
+        selectedColor: CanvasColor.defaultColor.color.toARGB32(),
+        selectedWidth: 3, // 펜 기본 굵기
+        allowedPointersMode: s.allowedPointersMode,
+        scaleFactor: s.scaleFactor,
+        activePointerIds: s.activePointerIds,
+      ),
+      // 현재 상태가 erasing 일 때, 펜 모드로 변경할 것임
+      erasing: (s) => ScribbleState.drawing(
+        sketch: s.sketch,
+        selectedColor: CanvasColor.defaultColor.color.toARGB32(),
+        selectedWidth: 3, // 펜 기본 굵기
+        allowedPointersMode: s.allowedPointersMode,
+        scaleFactor: s.scaleFactor,
+        activePointerIds: s.activePointerIds,
+      ),
+    );
+  }
+
+  void setHighlighter() {
+    toolMode = ToolMode.highlighter;
+    temporaryValue = value.map(
+      // 현재 상태가 drawing 일 때
+      drawing: (s) => ScribbleState.drawing(
+        sketch: s.sketch,
+        selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
+        selectedWidth: 20, // 하이라이터 기본 굵기
+        allowedPointersMode: s.allowedPointersMode,
+        scaleFactor: s.scaleFactor,
+        activePointerIds: s.activePointerIds,
+      ),
+      // 현재 상태가 erasing 일 때, 펜 모드로 변경할 것임
+      erasing: (s) => ScribbleState.drawing(
+        sketch: s.sketch,
+        selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
+        selectedWidth: 20, // 하이라이터 기본 굵기
+        allowedPointersMode: s.allowedPointersMode,
+        scaleFactor: s.scaleFactor,
+        activePointerIds: s.activePointerIds,
+      ),
+    );
+  }
+
+  @override
+  void setEraser() {
+    toolMode = ToolMode.eraser;
+    temporaryValue = ScribbleState.erasing(
+      sketch: value.sketch,
+      selectedWidth: 5, // 지우개 기본 굵기
+      scaleFactor: value.scaleFactor,
+      allowedPointersMode: value.allowedPointersMode,
+      activePointerIds: value.activePointerIds,
+    );
+  }
+
+  void setLinker() {
+    toolMode = ToolMode.linker;
+    temporaryValue = ScribbleState.drawing(
+      sketch: value.sketch,
+      selectedColor: Colors.pinkAccent.withValues(alpha: 0.5).toARGB32(),
+      selectedWidth: 30, // 링커 기본 굵기
+      allowedPointersMode: value.allowedPointersMode,
+      scaleFactor: value.scaleFactor,
+      activePointerIds: value.activePointerIds,
+    );
   }
 }

--- a/lib/models/custom_scribble_notifier.dart
+++ b/lib/models/custom_scribble_notifier.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:scribble/scribble.dart';
 
 import '../data/sketches.dart';
-import 'canvas_color.dart';
 import 'tool_mode.dart';
 
 class CustomScribbleNotifier extends ScribbleNotifier {
@@ -35,51 +34,35 @@ class CustomScribbleNotifier extends ScribbleNotifier {
     sketches[canvasIndex].jsonData = jsonEncode(json);
   }
 
-  void setPen() {
-    toolMode = ToolMode.pen;
-    temporaryValue = ScribbleState.drawing(
-      sketch: value.sketch,
-      selectedColor: CanvasColor.defaultColor.color.toARGB32(),
-      selectedWidth: 3, // 펜 기본 굵기
-      allowedPointersMode: value.allowedPointersMode,
-      scaleFactor: value.scaleFactor,
-      activePointerIds: value.activePointerIds,
-    );
+  /// 공통 도구 변경 메서드
+  void _setTool(ToolMode newToolMode) {
+    toolMode = newToolMode;
+
+    if (newToolMode.isDrawingMode) {
+      temporaryValue = ScribbleState.drawing(
+        sketch: value.sketch,
+        selectedColor: newToolMode.defaultColor.toARGB32(),
+        selectedWidth: newToolMode.defaultWidth,
+        allowedPointersMode: value.allowedPointersMode,
+        scaleFactor: value.scaleFactor,
+        activePointerIds: value.activePointerIds,
+      );
+    } else {
+      // 지우개 모드
+      temporaryValue = ScribbleState.erasing(
+        sketch: value.sketch,
+        selectedWidth: newToolMode.defaultWidth,
+        scaleFactor: value.scaleFactor,
+        allowedPointersMode: value.allowedPointersMode,
+        activePointerIds: value.activePointerIds,
+      );
+    }
   }
 
-  void setHighlighter() {
-    toolMode = ToolMode.highlighter;
-    temporaryValue = ScribbleState.drawing(
-      sketch: value.sketch,
-      selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
-      selectedWidth: 20, // 하이라이터 기본 굵기
-      allowedPointersMode: value.allowedPointersMode,
-      scaleFactor: value.scaleFactor,
-      activePointerIds: value.activePointerIds,
-    );
-  }
+  void setPen() => _setTool(ToolMode.pen);
+  void setHighlighter() => _setTool(ToolMode.highlighter);
+  void setLinker() => _setTool(ToolMode.linker);
 
   @override
-  void setEraser() {
-    toolMode = ToolMode.eraser;
-    temporaryValue = ScribbleState.erasing(
-      sketch: value.sketch,
-      selectedWidth: 5, // 지우개 기본 굵기
-      scaleFactor: value.scaleFactor,
-      allowedPointersMode: value.allowedPointersMode,
-      activePointerIds: value.activePointerIds,
-    );
-  }
-
-  void setLinker() {
-    toolMode = ToolMode.linker;
-    temporaryValue = ScribbleState.drawing(
-      sketch: value.sketch,
-      selectedColor: Colors.pinkAccent.withValues(alpha: 0.5).toARGB32(),
-      selectedWidth: 30, // 링커 기본 굵기
-      allowedPointersMode: value.allowedPointersMode,
-      scaleFactor: value.scaleFactor,
-      activePointerIds: value.activePointerIds,
-    );
-  }
+  void setEraser() => _setTool(ToolMode.eraser);
 }

--- a/lib/models/custom_scribble_notifier.dart
+++ b/lib/models/custom_scribble_notifier.dart
@@ -12,7 +12,7 @@ class CustomScribbleNotifier extends ScribbleNotifier {
     super.sketch,
     super.allowedPointersMode,
     super.maxHistoryLength,
-    super.widths,
+    super.widths = const [1, 3, 5, 7],
     super.pressureCurve,
     super.simplifier,
     super.simplificationTolerance,

--- a/lib/models/custom_scribble_notifier.dart
+++ b/lib/models/custom_scribble_notifier.dart
@@ -37,49 +37,25 @@ class CustomScribbleNotifier extends ScribbleNotifier {
 
   void setPen() {
     toolMode = ToolMode.pen;
-    temporaryValue = value.map(
-      // 현재 상태가 drawing 일 때
-      drawing: (s) => ScribbleState.drawing(
-        sketch: s.sketch,
-        selectedColor: CanvasColor.defaultColor.color.toARGB32(),
-        selectedWidth: 3, // 펜 기본 굵기
-        allowedPointersMode: s.allowedPointersMode,
-        scaleFactor: s.scaleFactor,
-        activePointerIds: s.activePointerIds,
-      ),
-      // 현재 상태가 erasing 일 때, 펜 모드로 변경할 것임
-      erasing: (s) => ScribbleState.drawing(
-        sketch: s.sketch,
-        selectedColor: CanvasColor.defaultColor.color.toARGB32(),
-        selectedWidth: 3, // 펜 기본 굵기
-        allowedPointersMode: s.allowedPointersMode,
-        scaleFactor: s.scaleFactor,
-        activePointerIds: s.activePointerIds,
-      ),
+    temporaryValue = ScribbleState.drawing(
+      sketch: value.sketch,
+      selectedColor: CanvasColor.defaultColor.color.toARGB32(),
+      selectedWidth: 3, // 펜 기본 굵기
+      allowedPointersMode: value.allowedPointersMode,
+      scaleFactor: value.scaleFactor,
+      activePointerIds: value.activePointerIds,
     );
   }
 
   void setHighlighter() {
     toolMode = ToolMode.highlighter;
-    temporaryValue = value.map(
-      // 현재 상태가 drawing 일 때
-      drawing: (s) => ScribbleState.drawing(
-        sketch: s.sketch,
-        selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
-        selectedWidth: 20, // 하이라이터 기본 굵기
-        allowedPointersMode: s.allowedPointersMode,
-        scaleFactor: s.scaleFactor,
-        activePointerIds: s.activePointerIds,
-      ),
-      // 현재 상태가 erasing 일 때, 펜 모드로 변경할 것임
-      erasing: (s) => ScribbleState.drawing(
-        sketch: s.sketch,
-        selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
-        selectedWidth: 20, // 하이라이터 기본 굵기
-        allowedPointersMode: s.allowedPointersMode,
-        scaleFactor: s.scaleFactor,
-        activePointerIds: s.activePointerIds,
-      ),
+    temporaryValue = ScribbleState.drawing(
+      sketch: value.sketch,
+      selectedColor: CanvasColor.defaultColor.highlighterColor.toARGB32(),
+      selectedWidth: 20, // 하이라이터 기본 굵기
+      allowedPointersMode: value.allowedPointersMode,
+      scaleFactor: value.scaleFactor,
+      activePointerIds: value.activePointerIds,
     );
   }
 

--- a/lib/models/tool_mode.dart
+++ b/lib/models/tool_mode.dart
@@ -1,3 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'canvas_color.dart';
+
 enum ToolMode {
   pen('Pen', [1, 3, 5, 7]),
   eraser('Eraser', [3, 5, 7]),
@@ -8,4 +12,35 @@ enum ToolMode {
 
   final String displayName;
   final List<double> widths;
+
+  /// 각 도구의 기본 굵기 (widths 리스트의 첫 번째 또는 중간 값)
+  double get defaultWidth {
+    switch (this) {
+      case ToolMode.pen:
+        return 3.0;
+      case ToolMode.eraser:
+        return 5.0;
+      case ToolMode.highlighter:
+        return 20.0;
+      case ToolMode.linker:
+        return 20.0;
+    }
+  }
+
+  /// 각 도구의 기본 색상
+  Color get defaultColor {
+    switch (this) {
+      case ToolMode.pen:
+        return CanvasColor.defaultColor.color;
+      case ToolMode.eraser:
+        return Colors.transparent; // 지우개는 색상 없음
+      case ToolMode.highlighter:
+        return CanvasColor.defaultColor.highlighterColor;
+      case ToolMode.linker:
+        return Colors.pinkAccent.withValues(alpha: 0.5);
+    }
+  }
+
+  /// 각 도구가 그리기 모드인지 지우기 모드인지
+  bool get isDrawingMode => this != ToolMode.eraser;
 }

--- a/lib/models/tool_mode.dart
+++ b/lib/models/tool_mode.dart
@@ -1,0 +1,10 @@
+enum ToolMode {
+  pen('Pen'),
+  eraser('Eraser'),
+  highlighter('Highlighter'),
+  linker('Linker');
+
+  const ToolMode(this.displayName);
+
+  final String displayName;
+}

--- a/lib/models/tool_mode.dart
+++ b/lib/models/tool_mode.dart
@@ -1,10 +1,11 @@
 enum ToolMode {
-  pen('Pen'),
-  eraser('Eraser'),
-  highlighter('Highlighter'),
-  linker('Linker');
+  pen('Pen', [1, 3, 5, 7]),
+  eraser('Eraser', [3, 5, 7]),
+  highlighter('Highlighter', [10, 20, 30]),
+  linker('Linker', [10, 20, 30]);
 
-  const ToolMode(this.displayName);
+  const ToolMode(this.displayName, this.widths);
 
   final String displayName;
+  final List<double> widths;
 }

--- a/lib/pages/canvas_page.dart
+++ b/lib/pages/canvas_page.dart
@@ -57,7 +57,7 @@ class _CanvasPageState extends State<CanvasPage> {
     notifier = CustomScribbleNotifier(
       maxHistoryLength: 100,
       // widths 는 자동 관리되긴 할 것임
-      widths: const [1, 3, 5, 7],
+      // widths: const [1, 3, 5, 7],
       // pressureCurve: Curves.easeInOut,
       canvasIndex: widget.canvasIndex,
       // TODO(xodnd): 초기 모드 설정 필요

--- a/lib/pages/canvas_page.dart
+++ b/lib/pages/canvas_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:scribble/scribble.dart';
 
 import '../data/sketches.dart';
-import '../models/canvas_color.dart';
 import '../models/custom_scribble_notifier.dart';
+import '../models/tool_mode.dart';
 import '../widgets/canvas/canvas_actions.dart';
 import '../widgets/canvas/canvas_background.dart';
 import '../widgets/canvas/canvas_info.dart';
@@ -60,6 +60,8 @@ class _CanvasPageState extends State<CanvasPage> {
       widths: const [1, 3, 5, 7],
       // pressureCurve: Curves.easeInOut,
       canvasIndex: widget.canvasIndex,
+      // TODO(xodnd): 초기 모드 설정 필요
+      toolMode: ToolMode.highlighter,
     );
 
     // 초기 스케치 설정
@@ -68,10 +70,9 @@ class _CanvasPageState extends State<CanvasPage> {
       addToUndoHistory: false, // 초기 설정이므로 undo 히스토리에 추가하지 않음
     );
 
-    // 기본 색상 설정
-    notifier.setColor(CanvasColor.defaultColor.color);
-    // 기본 굵기 설정
-    notifier.setStrokeWidth(3);
+    // toolMode에 따른 초기 설정 테스트중 - 성공
+    // TODO(xodnd): 펜 모드로 복구
+    notifier.setHighlighter();
 
     transformationController = TransformationController();
 
@@ -107,6 +108,7 @@ class _CanvasPageState extends State<CanvasPage> {
                   surfaceTintColor: Colors.white,
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(6),
+                    // TODO(xodnd): 캔버스 기본 로딩 시 중앙 정렬 필요
                     child: InteractiveViewer(
                       transformationController: transformationController,
                       minScale: 0.3,

--- a/lib/pages/canvas_page.dart
+++ b/lib/pages/canvas_page.dart
@@ -25,14 +25,14 @@ class CanvasPage extends StatefulWidget {
 }
 
 class _CanvasPageState extends State<CanvasPage> {
-  /// ScribbleNotifier: 그리기 상태를 관리하는 핵심 컨트롤러
+  /// CustomScribbleNotifier: 그리기 상태를 관리하는 핵심 컨트롤러
   ///
   /// 이 객체는 다음을 관리합니다:
   /// - 현재 그림 데이터 (스케치)
-  /// - 선택된 색상, 굵기, 도구 상태
+  /// - 선택된 색상, 굵기, 도구 상태 (펜/하이라이터/지우개)
   /// - Undo/Redo 히스토리
-  /// - 그리기 모드 (펜/지우개)
-  late ScribbleNotifier notifier;
+  /// - 그리기 모드 및 도구별 설정
+  late CustomScribbleNotifier notifier;
 
   /// TransformationController: 확대/축소 상태를 관리하는 컨트롤러
   ///
@@ -56,6 +56,7 @@ class _CanvasPageState extends State<CanvasPage> {
     // 컨트롤러 초기화
     notifier = CustomScribbleNotifier(
       maxHistoryLength: 100,
+      // widths 는 자동 관리되긴 할 것임
       widths: const [1, 3, 5, 7],
       // pressureCurve: Curves.easeInOut,
       canvasIndex: widget.canvasIndex,
@@ -160,6 +161,8 @@ class _CanvasPageState extends State<CanvasPage> {
                       children: [
                         CanvasToolbar(notifier: notifier),
                         // 필압 토글 컨트롤
+                        // TODO(xodnd): notifier 에서 처리하는 것이 좋을 것 같음.
+                        // TODO(xodnd): simplify 0 으로 수정 필요
                         PressureToggle(
                           simulatePressure: _simulatePressure,
                           onChanged: (value) {

--- a/lib/widgets/canvas/canvas_toolbar.dart
+++ b/lib/widgets/canvas/canvas_toolbar.dart
@@ -77,10 +77,23 @@ class ColorToolbar extends StatelessWidget {
         child: ColorButton(
           color: color,
           isActive: state is Drawing && state.selectedColor == color.toARGB32(),
-          onPressed: () => {
-            if (toolMode == ToolMode.pen) notifier.setPen(),
-            if (toolMode == ToolMode.highlighter) notifier.setHighlighter(),
-            notifier.setColor(color),
+          onPressed: () {
+            // 현재 도구가 아닌 경우 먼저 도구 변경
+            if (notifier.toolMode != toolMode) {
+              switch (toolMode) {
+                case ToolMode.pen:
+                  notifier.setPen();
+                case ToolMode.highlighter:
+                  notifier.setHighlighter();
+                case ToolMode.linker:
+                  notifier.setLinker();
+                case ToolMode.eraser:
+                  // 지우개는 색상 변경 불가
+                  return;
+              }
+            }
+            // 색상 변경
+            notifier.setColor(color);
           },
           tooltip: tooltip,
         ),

--- a/lib/widgets/canvas/canvas_toolbar.dart
+++ b/lib/widgets/canvas/canvas_toolbar.dart
@@ -7,15 +7,6 @@ import '../../models/tool_mode.dart';
 import 'color_button.dart';
 import 'drawing_mode_toolbar.dart';
 
-/* TODO
- * 펜 선택
- * 펜 색상
- * 지우개 선택
- * 하이라이터 선택
- * 하이라이터 색상
- * 펜 / 하이라이터 굵기 (펜 별 굵기 옵션 달라짐)
- */
-
 class CanvasToolbar extends StatelessWidget {
   const CanvasToolbar({
     required this.notifier,
@@ -114,7 +105,7 @@ class StrokeToolbar extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
-          for (final w in notifier.widths)
+          for (final w in notifier.toolMode.widths)
             _buildStrokeButton(
               context,
               strokeWidth: w,

--- a/lib/widgets/canvas/canvas_toolbar.dart
+++ b/lib/widgets/canvas/canvas_toolbar.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:scribble/scribble.dart';
 
 import '../../models/canvas_color.dart';
+import '../../models/custom_scribble_notifier.dart';
+import '../../models/tool_mode.dart';
 import 'color_button.dart';
 
 /* TODO
@@ -13,20 +15,13 @@ import 'color_button.dart';
  * 펜 / 하이라이터 굵기 (펜 별 굵기 옵션 달라짐)
  */
 
-enum DrawingMode {
-  pen,
-  eraser,
-  highlighter,
-  linker,
-}
-
 class CanvasToolbar extends StatelessWidget {
   const CanvasToolbar({
     required this.notifier,
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +46,7 @@ class DrawingModeToolbar extends StatelessWidget {
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {
@@ -59,23 +54,23 @@ class DrawingModeToolbar extends StatelessWidget {
       children: [
         _buildDrawingModeButton(
           context,
-          drawingMode: DrawingMode.pen,
-          tooltip: 'Pen',
+          drawingMode: ToolMode.pen,
+          tooltip: ToolMode.pen.displayName,
         ),
         _buildDrawingModeButton(
           context,
-          drawingMode: DrawingMode.eraser,
-          tooltip: 'Eraser',
+          drawingMode: ToolMode.eraser,
+          tooltip: ToolMode.eraser.displayName,
         ),
         _buildDrawingModeButton(
           context,
-          drawingMode: DrawingMode.highlighter,
-          tooltip: 'Highlighter',
+          drawingMode: ToolMode.highlighter,
+          tooltip: ToolMode.highlighter.displayName,
         ),
         _buildDrawingModeButton(
           context,
-          drawingMode: DrawingMode.linker,
-          tooltip: 'Linker',
+          drawingMode: ToolMode.linker,
+          tooltip: ToolMode.linker.displayName,
         ),
       ],
     );
@@ -83,37 +78,37 @@ class DrawingModeToolbar extends StatelessWidget {
 
   Widget _buildDrawingModeButton(
     BuildContext context, {
-    required DrawingMode drawingMode,
+    required ToolMode drawingMode,
     required String tooltip,
   }) {
     return ValueListenableBuilder<ScribbleState>(
       valueListenable: notifier,
       builder: (context, state, child) {
-        // 현재 선택된 도구인지 확인
-        final isSelected = _isDrawingModeSelected(state, drawingMode);
-
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4),
           child: FilledButton(
             style: FilledButton.styleFrom(
-              backgroundColor: isSelected ? Colors.blue : null,
-              foregroundColor: isSelected ? Colors.white : null,
+              backgroundColor: notifier.toolMode == drawingMode
+                  ? Colors.blue
+                  : null,
+              foregroundColor: notifier.toolMode == drawingMode
+                  ? Colors.white
+                  : null,
             ),
             onPressed: () {
+              print('onPressed: $drawingMode');
               switch (drawingMode) {
-                case DrawingMode.pen:
-                  notifier.setColor(CanvasColor.defaultColor.color);
+                case ToolMode.pen:
+                  notifier.setPen();
                   break;
-                case DrawingMode.eraser:
+                case ToolMode.eraser:
                   notifier.setEraser();
                   break;
-                case DrawingMode.highlighter:
-                  notifier.setColor(CanvasColor.defaultColor.highlighterColor);
-                  notifier.setStrokeWidth(20);
+                case ToolMode.highlighter:
+                  notifier.setHighlighter();
                   break;
-                case DrawingMode.linker:
-                  notifier.setColor(Colors.pinkAccent.withValues(alpha: 0.5));
-                  notifier.setStrokeWidth(30);
+                case ToolMode.linker:
+                  notifier.setLinker();
                   break;
               }
             },
@@ -123,24 +118,6 @@ class DrawingModeToolbar extends StatelessWidget {
       },
     );
   }
-
-  bool _isDrawingModeSelected(ScribbleState state, DrawingMode mode) {
-    switch (mode) {
-      case DrawingMode.eraser:
-        return state is Erasing;
-      case DrawingMode.pen:
-        return state is Drawing &&
-            state.selectedColor == CanvasColor.defaultColor.color.toARGB32();
-      case DrawingMode.highlighter:
-        return state is Drawing &&
-            state.selectedColor ==
-                CanvasColor.defaultColor.highlighterColor.toARGB32();
-      case DrawingMode.linker:
-        return state is Drawing &&
-            state.selectedColor ==
-                Colors.pinkAccent.withValues(alpha: 0.5).toARGB32();
-    }
-  }
 }
 
 class ColorToolbar extends StatelessWidget {
@@ -149,7 +126,7 @@ class ColorToolbar extends StatelessWidget {
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {
@@ -197,7 +174,7 @@ class EraserButton extends StatelessWidget {
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {
@@ -220,7 +197,7 @@ class StrokeToolbar extends StatelessWidget {
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {
@@ -305,7 +282,7 @@ class PointerModeSwitcher extends StatelessWidget {
     super.key,
   });
 
-  final ScribbleNotifier notifier;
+  final CustomScribbleNotifier notifier;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/canvas/drawing_mode_toolbar.dart
+++ b/lib/widgets/canvas/drawing_mode_toolbar.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:scribble/scribble.dart';
+
+import '../../models/custom_scribble_notifier.dart';
+import '../../models/tool_mode.dart';
+
+class DrawingModeToolbar extends StatelessWidget {
+  const DrawingModeToolbar({
+    required this.notifier,
+    super.key,
+  });
+
+  final CustomScribbleNotifier notifier;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _buildDrawingModeButton(
+          context,
+          drawingMode: ToolMode.pen,
+          tooltip: 'Pen',
+        ),
+        _buildDrawingModeButton(
+          context,
+          drawingMode: ToolMode.eraser,
+          tooltip: ToolMode.eraser.displayName,
+        ),
+        _buildDrawingModeButton(
+          context,
+          drawingMode: ToolMode.highlighter,
+          tooltip: ToolMode.highlighter.displayName,
+        ),
+        _buildDrawingModeButton(
+          context,
+          drawingMode: ToolMode.linker,
+          tooltip: ToolMode.linker.displayName,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDrawingModeButton(
+    BuildContext context, {
+    required ToolMode drawingMode,
+    required String tooltip,
+  }) {
+    return ValueListenableBuilder<ScribbleState>(
+      valueListenable: notifier,
+      builder: (context, state, child) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: notifier.toolMode == drawingMode
+                  ? Colors.blue
+                  : null,
+              foregroundColor: notifier.toolMode == drawingMode
+                  ? Colors.white
+                  : null,
+            ),
+            onPressed: () {
+              print('onPressed: $drawingMode');
+              switch (drawingMode) {
+                case ToolMode.pen:
+                  notifier.setPen();
+                  break;
+                case ToolMode.eraser:
+                  notifier.setEraser();
+                  break;
+                case ToolMode.highlighter:
+                  notifier.setHighlighter();
+                  break;
+                case ToolMode.linker:
+                  notifier.setLinker();
+                  break;
+              }
+            },
+            child: Text(tooltip),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 🎨 캔버스 도구별 맞춤형 그리기 시스템 구현

### 📌 변경사항 요약
펜, 하이라이터, 지우개, 링커 각각의 특성에 맞는 도구별 맞춤형 그리기 시스템을 구현했습니다.

### ✨ 주요 기능
- **📏 도구별 굵기 옵션**: 각 도구마다 최적화된 굵기 선택지 제공
  - 펜: 1, 3, 5, 7px (정밀한 필기용)
  - 하이라이터: 10, 20, 30px (강조용)
  - 지우개: 3, 5, 7px (정밀한 지우기)
  - 링커: 10, 20, 30px (연결선용)

- **🎨 도구별 색상 시스템**: 펜과 하이라이터 각각 독립적인 색상 팔레트
  - 펜: 일반 색상으로 정밀한 필기
  - 하이라이터: 반투명 색상으로 텍스트 강조

- **🔄 실시간 도구 전환**: 도구 변경 시 즉시 해당 도구의 옵션으로 UI 업데이트

### 🏗️ 기술적 개선사항
- **ToolMode enum 확장**: 각 도구별 기본 설정 중앙 집중 관리
- **CustomScribbleNotifier 리팩토링**: 중복 코드 제거 (50줄 → 20줄)
- **ValueListenableBuilder 최적화**: 개별 컴포넌트 단위 리렌더링으로 성능 개선

### 🎯 사용자 경험 개선
- 도구 변경 시 자동으로 해당 도구에 맞는 굵기 옵션 표시
- 색상 선택 시 자동으로 해당 도구 모드로 전환
- 직관적이고 일관된 도구 선택 플로우

### 🧪 테스트 완료
- [ ] 각 도구별 굵기 옵션 정상 작동 확인
- [ ] 도구 간 전환 시 UI 업데이트 확인
- [ ] 색상 선택 시 도구 모드 전환 확인
- [ ] 지우개 모드에서 색상 선택 비활성화 확인

### 📱 사용 방법
1. 상단 툴바에서 원하는 도구 선택 (펜/하이라이터/지우개/링커)
2. 해당 도구에 맞는 색상과 굵기 선택
3. 캔버스에서 자유롭게 그리기/지우기

### 📋 관련 이슈
- 펜 선택 및 툴바 기능 구현 완료
- 도구별 굵기 옵션 분리 완료
- 코드 중복 제거 및 유지보수성 개선 완료

### 🔜 향후 계획
- 도구별 투명도 조절 기능 추가 고려
- 커스텀 굵기 설정 기능 추가 고려
- 도구 설정 저장/불러오기 기능 추가 고려